### PR TITLE
fix: correct amount_delta calculation from destorying

### DIFF
--- a/lib/transfer/changes/verify_transfer.ex
+++ b/lib/transfer/changes/verify_transfer.ex
@@ -41,10 +41,17 @@ defmodule AshDoubleEntry.Transfer.Changes.VerifyTransfer do
       |> Ash.Changeset.after_action(fn changeset, result ->
         from_account_id = Ash.Changeset.get_attribute(changeset, :from_account_id)
         to_account_id = Ash.Changeset.get_attribute(changeset, :to_account_id)
-        amount = Ash.Changeset.get_attribute(changeset, :amount)
+        new_amount = Ash.Changeset.get_attribute(changeset, :amount)
+
+        old_amount =
+          if changeset.action.type == :destroy do
+            Money.new!(0, new_amount.currency)
+          else
+            changeset.data.amount || Money.new!(0, new_amount.currency)
+          end
 
         amount_delta =
-          Money.sub!(amount, changeset.data.amount || Money.new!(0, amount.currency))
+          Money.sub!(new_amount, old_amount)
 
         accounts =
           changeset.resource

--- a/test/ash_double_entry_test.exs
+++ b/test/ash_double_entry_test.exs
@@ -287,14 +287,15 @@ defmodule AshDoubleEntryTest do
         })
         |> Api.create!()
 
-      Transfer
-      |> Ash.Changeset.for_create(:transfer, %{
-        amount: Money.new!(:USD, 20),
-        from_account_id: account_two.id,
-        to_account_id: account_one.id,
-        timestamp: DateTime.add(now, -2, :minute)
-      })
-      |> Api.create!()
+      transfer_2 =
+        Transfer
+        |> Ash.Changeset.for_create(:transfer, %{
+          amount: Money.new!(:USD, 20),
+          from_account_id: account_two.id,
+          to_account_id: account_one.id,
+          timestamp: DateTime.add(now, -2, :minute)
+        })
+        |> Api.create!()
 
       assert Money.equal?(
                Api.load!(account_one, :balance_as_of).balance_as_of,
@@ -304,18 +305,30 @@ defmodule AshDoubleEntryTest do
       assert Money.equal?(
                Api.load!(account_two, :balance_as_of).balance_as_of,
                Money.new!(:USD, 0)
+             )
+
+      transfer_2 |> Api.destroy!()
+
+      assert Money.equal?(
+               Api.load!(account_one, :balance_as_of).balance_as_of,
+               Money.new!(:USD, -20)
+             )
+
+      assert Money.equal?(
+               Api.load!(account_two, :balance_as_of).balance_as_of,
+               Money.new!(:USD, 20)
              )
 
       transfer_1 |> Api.destroy!()
 
       assert Money.equal?(
                Api.load!(account_one, :balance_as_of).balance_as_of,
-               Money.new!(:USD, 20)
+               Money.new!(:USD, 0)
              )
 
       assert Money.equal?(
                Api.load!(account_two, :balance_as_of).balance_as_of,
-               Money.new!(:USD, -20)
+               Money.new!(:USD, 0)
              )
     end
 


### PR DESCRIPTION
Unfortunately, current test case doesn't cover the verifying logic when destorying, so this bug wasn't caught previously.

### Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
