### PR TITLE
fix(#150): added `before?/1` clauses to the three transformers for `SetRelationshipSource`

### DIFF
--- a/lib/account/transformers/add_structure.ex
+++ b/lib/account/transformers/add_structure.ex
@@ -8,6 +8,7 @@ defmodule AshDoubleEntry.Account.Transformers.AddStructure do
   use Spark.Dsl.Transformer
   import Spark.Dsl.Builder
 
+  def before?(Ash.Resource.Transformers.SetRelationshipSource), do: true
   def before?(Ash.Resource.Transformers.BelongsToAttribute), do: true
   def before?(Ash.Resource.Transformers.CachePrimaryKey), do: true
   def before?(_), do: false

--- a/lib/balance/transformers/add_structure.ex
+++ b/lib/balance/transformers/add_structure.ex
@@ -9,6 +9,7 @@ defmodule AshDoubleEntry.Balance.Transformers.AddStructure do
   import Spark.Dsl.Builder
   import Ash.Expr
 
+  def before?(Ash.Resource.Transformers.SetRelationshipSource), do: true
   def before?(Ash.Resource.Transformers.CachePrimaryKey), do: true
   def before?(Ash.Resource.Transformers.BelongsToAttribute), do: true
   def before?(_), do: false

--- a/lib/transfer/transformers/add_structure.ex
+++ b/lib/transfer/transformers/add_structure.ex
@@ -7,6 +7,7 @@ defmodule AshDoubleEntry.Transfer.Transformers.AddStructure do
   @moduledoc false
   use Spark.Dsl.Transformer
 
+  def before?(Ash.Resource.Transformers.SetRelationshipSource), do: true
   def before?(Ash.Resource.Transformers.CachePrimaryKey), do: true
   def before?(Ash.Resource.Transformers.BelongsToSourceField), do: true
   def before?(Ash.Resource.Transformers.BelongsToAttribute), do: true


### PR DESCRIPTION
Added checks to make sure the `AddStructure` transformers will execute before the `Ash.Resource.Transformers.SetRelationshipSource` transformer.

This fixes the failing tests, but I'm not sure if this is how it should be fixed, as the other transformer is not part of this repository. The fix was proposed by opencode  

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
