### PR TITLE
Make read_transfers pagination optional (required?: false)

### DIFF
--- a/lib/transfer/transformers/add_structure.ex
+++ b/lib/transfer/transformers/add_structure.ex
@@ -53,7 +53,7 @@ defmodule AshDoubleEntry.Transfer.Transformers.AddStructure do
           AshDoubleEntry.Transfer.Info.transfer_create_accept!(dsl)
     )
     |> Ash.Resource.Builder.add_action(:read, :read_transfers,
-      pagination: Ash.Resource.Builder.build_pagination(keyset?: true)
+      pagination: Ash.Resource.Builder.build_pagination(keyset?: true, required?: false)
     )
     |> Ash.Resource.Builder.add_change({AshDoubleEntry.Transfer.Changes.VerifyTransfer, []},
       only_when_valid?: true,


### PR DESCRIPTION
The read_transfers action was created with keyset pagination where
required? defaults to true. This forces all reads to use pagination.

When consumers filter by ULID range (id >= start AND id < end) —
a common pattern for time-based queries on transfer history — the
keyset cursor conflicts with the range bounds. The cursor advances
past records that fall within the requested range, returning
incomplete results.

With required?: false, consumers can opt out of pagination for
filtered queries (by not passing a page: option) while keyset
pagination remains available for paginated use cases.
